### PR TITLE
fix: 🐛 修复setting路由不存在问题

### DIFF
--- a/src/pages.json
+++ b/src/pages.json
@@ -22,9 +22,9 @@
       "path": "pages/setting",
       "type": "page",
       "layout": "tabbar",
-      "name": "hi",
+      "name": "setting",
       "style": {
-        "navigationBarTitleText": "hi"
+        "navigationBarTitleText": "setting"
       }
     }
   ],

--- a/src/pages/setting.vue
+++ b/src/pages/setting.vue
@@ -33,9 +33,9 @@ function change() {
 <route lang="json">
 {
   "layout": "tabbar",
-  "name": "hi",
+  "name": "setting",
   "style": {
-    "navigationBarTitleText": "hi"
+    "navigationBarTitleText": "setting"
   }
 }
 </route>


### PR DESCRIPTION
目前，直接拉取项目后，setting页面是无法打开的，本PR修复了这个小问题
Currently, after directly pulling the project, the setting page cannot be opened. This PR has fixed this minor issue